### PR TITLE
remove `.spv`

### DIFF
--- a/src/raytracer/RayTracingApplication.cs
+++ b/src/raytracer/RayTracingApplication.cs
@@ -509,7 +509,7 @@ namespace RayTracer
                     extension = "hlsl.bytes";
                     break;
                 case GraphicsBackend.Vulkan:
-                    extension = "450.glsl.spv";
+                    extension = "450.glsl";
                     break;
                 case GraphicsBackend.OpenGL:
                     extension = "330.glsl";


### PR DESCRIPTION
changing `backend` to `GraphicsBackend.Vulkan` throws me errors (couldn't find `*.glsl.spv` file)
this fixes it